### PR TITLE
Add bullseye, eoan and focal

### DIFF
--- a/deb/conf/distributions
+++ b/deb/conf/distributions
@@ -32,6 +32,14 @@ SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C
 
 Origin: knqyf263.github.io/trivy-repo/deb
 Label: github.io/knqyf263
+Codename: bullseye
+Architectures: i386 amd64
+Components: main
+Description: Trivy repository
+SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C
+
+Origin: knqyf263.github.io/trivy-repo/deb
+Label: github.io/knqyf263
 Codename: trusty
 Architectures: i386 amd64
 Components: main
@@ -49,6 +57,22 @@ SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C
 Origin: knqyf263.github.io/trivy-repo/deb
 Label: github.io/knqyf263
 Codename: bionic
+Architectures: i386 amd64
+Components: main
+Description: Trivy repository
+SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C
+
+Origin: knqyf263.github.io/trivy-repo/deb
+Label: github.io/knqyf263
+Codename: eoan
+Architectures: i386 amd64
+Components: main
+Description: Trivy repository
+SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C
+
+Origin: knqyf263.github.io/trivy-repo/deb
+Label: github.io/knqyf263
+Codename: focal
 Architectures: i386 amd64
 Components: main
 Description: Trivy repository


### PR DESCRIPTION
bullseye: Debian 11 "Bullseye"
eoan: Ubuntu 19.10 "Eoan Ermine"
focal: Ubuntu 20.04 LTS "Focal Fossa"