### PR TITLE
Add arm64 arch in distributions

### DIFF
--- a/deb/conf/distributions
+++ b/deb/conf/distributions
@@ -1,7 +1,7 @@
 Origin: knqyf263.github.io/trivy-repo/deb
 Label: github.io/knqyf263
 Codename: wheezy
-Architectures: i386 amd64
+Architectures: i386 amd64 arm64
 Components: main
 Description: Trivy repository
 SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C
@@ -9,7 +9,7 @@ SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C
 Origin: knqyf263.github.io/trivy-repo/deb
 Label: github.io/knqyf263
 Codename: jessie
-Architectures: i386 amd64
+Architectures: i386 amd64 arm64
 Components: main
 Description: Trivy repository
 SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C
@@ -17,7 +17,7 @@ SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C
 Origin: knqyf263.github.io/trivy-repo/deb
 Label: github.io/knqyf263
 Codename: stretch
-Architectures: i386 amd64
+Architectures: i386 amd64 arm64
 Components: main
 Description: Trivy repository
 SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C
@@ -25,7 +25,7 @@ SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C
 Origin: knqyf263.github.io/trivy-repo/deb
 Label: github.io/knqyf263
 Codename: buster
-Architectures: i386 amd64
+Architectures: i386 amd64 arm64
 Components: main
 Description: Trivy repository
 SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C
@@ -33,7 +33,7 @@ SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C
 Origin: knqyf263.github.io/trivy-repo/deb
 Label: github.io/knqyf263
 Codename: bullseye
-Architectures: i386 amd64
+Architectures: i386 amd64 arm64
 Components: main
 Description: Trivy repository
 SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C
@@ -41,7 +41,7 @@ SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C
 Origin: knqyf263.github.io/trivy-repo/deb
 Label: github.io/knqyf263
 Codename: trusty
-Architectures: i386 amd64
+Architectures: i386 amd64 arm64
 Components: main
 Description: Trivy repository
 SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C
@@ -49,7 +49,7 @@ SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C
 Origin: knqyf263.github.io/trivy-repo/deb
 Label: github.io/knqyf263
 Codename: xenial
-Architectures: i386 amd64
+Architectures: i386 amd64 arm64
 Components: main
 Description: Trivy repository
 SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C
@@ -57,7 +57,7 @@ SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C
 Origin: knqyf263.github.io/trivy-repo/deb
 Label: github.io/knqyf263
 Codename: bionic
-Architectures: i386 amd64
+Architectures: i386 amd64 arm64
 Components: main
 Description: Trivy repository
 SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C
@@ -65,7 +65,7 @@ SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C
 Origin: knqyf263.github.io/trivy-repo/deb
 Label: github.io/knqyf263
 Codename: eoan
-Architectures: i386 amd64
+Architectures: i386 amd64 arm64
 Components: main
 Description: Trivy repository
 SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C
@@ -73,7 +73,7 @@ SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C
 Origin: knqyf263.github.io/trivy-repo/deb
 Label: github.io/knqyf263
 Codename: focal
-Architectures: i386 amd64
+Architectures: i386 amd64 arm64
 Components: main
 Description: Trivy repository
 SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C


### PR DESCRIPTION
Fix https://github.com/aquasecurity/trivy/issues/1455

@knqyf263 