### PR TITLE
Add configs for Ubuntu 21.10 (`impish`) and Ubuntu 22.04(`jammy`)

### DIFF
--- a/deb/conf/distributions
+++ b/deb/conf/distributions
@@ -1,5 +1,13 @@
 Origin: knqyf263.github.io/trivy-repo/deb
 Label: github.io/knqyf263
+Codename: jammy
+Architectures: i386 amd64 arm64
+Components: main
+Description: Trivy repository
+SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C
+
+Origin: knqyf263.github.io/trivy-repo/deb
+Label: github.io/knqyf263
 Codename: impish
 Architectures: i386 amd64 arm64
 Components: main

--- a/deb/conf/distributions
+++ b/deb/conf/distributions
@@ -1,5 +1,13 @@
 Origin: knqyf263.github.io/trivy-repo/deb
 Label: github.io/knqyf263
+Codename: impish
+Architectures: i386 amd64 arm64
+Components: main
+Description: Trivy repository
+SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C
+
+Origin: knqyf263.github.io/trivy-repo/deb
+Label: github.io/knqyf263
 Codename: wheezy
 Architectures: i386 amd64 arm64
 Components: main


### PR DESCRIPTION
Add support dep packages for Ubuntu 21.10 Impish and Ubuntu 22.04 Jammy.

Fixes https://github.com/aquasecurity/trivy/issues/1692