### PR TITLE
docs: add gpg check for rpm packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ $ sudo vim /etc/yum.repos.d/trivy.repo
 [trivy]
 name=Trivy repository
 baseurl=https://aquasecurity.github.io/trivy-repo/rpm/releases/$releasever/$basearch/
-gpgcheck=0
+gpgcheck=1
 enabled=1
+gpgkey=https://aquasecurity.github.io/trivy-repo/rpm/public.key
 $ sudo yum -y update
 $ sudo yum -y install trivy
 ```


### PR DESCRIPTION
after merging https://github.com/aquasecurity/trivy/pull/3612 Trivy RPM packages will contain GPG signatures for checking.
so we have to add it.