### PR TITLE
docs: add gpg check for rpm packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ $ sudo vim /etc/yum.repos.d/trivy.repo
 [trivy]
 name=Trivy repository
 baseurl=https://aquasecurity.github.io/trivy-repo/rpm/releases/$releasever/$basearch/
-gpgcheck=0
+gpgcheck=1
 enabled=1
+gpgkey=https://aquasecurity.github.io/trivy-repo/rpm/public.key
+
 $ sudo yum -y update
 $ sudo yum -y install trivy
 ```


### PR DESCRIPTION
Trivy v0.40.0 contains GPG signatures for checking RPM packages.
so we have to add it.