### PR TITLE
docs: remove `releasever` for yum repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Add repository setting
 $ sudo vim /etc/yum.repos.d/trivy.repo
 [trivy]
 name=Trivy repository
-baseurl=https://aquasecurity.github.io/trivy-repo/rpm/releases/$releasever/$basearch/
+baseurl=https://aquasecurity.github.io/trivy-repo/rpm/releases/$basearch/
 gpgcheck=1
 enabled=1
 gpgkey=https://aquasecurity.github.io/trivy-repo/rpm/public.key


### PR DESCRIPTION
After [aquasecurity/trivy#4077](https://github.com/aquasecurity/trivy/pull/4077)  we can use the path without any versions.