### PR TITLE
feat(ubuntu): add `mantic` and `noble` releases support

### DIFF
--- a/deb/conf/distributions
+++ b/deb/conf/distributions
@@ -117,3 +117,19 @@ Architectures: i386 amd64 arm64
 Components: main
 Description: Trivy repository
 SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C
+
+Origin: aquasecurity.github.io/trivy-repo/deb
+Label: github.io/aquasecurity
+Codename: mantic
+Architectures: i386 amd64 arm64
+Components: main
+Description: Trivy repository
+SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C
+
+Origin: aquasecurity.github.io/trivy-repo/deb
+Label: github.io/aquasecurity
+Codename: noble
+Architectures: i386 amd64 arm64
+Components: main
+Description: Trivy repository
+SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C


### PR DESCRIPTION
## Description
Add `mantic` and `noble` releases support.

Releases names:
```bash
root@a28e52e90583:/# distro-info --supported
...
mantic
noble
```

Test run - 