### PR TITLE
feat(deb): add common dist

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,12 @@ deb/rpm repository for Trivy
 ## Debian/Ubuntu
 
 ```
-$ sudo apt-get install apt-transport-https
-$ wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | sudo apt-key add -
-$ echo deb https://aquasecurity.github.io/trivy-repo/deb [CODE_NAME] main | sudo tee -a /etc/apt/sources.list
+$ apt-get install wget apt-transport-https gnupg
+$ wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | gpg --dearmor | sudo tee /usr/share/keyrings/trivy.gpg > /dev/null
+$ echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb common main" | sudo tee -a /etc/apt/sources.list.d/trivy.list
 $ sudo apt-get update
 $ sudo apt-get install trivy
 ```
-
-CODE_NAME: wheezy, jessie, stretch, buster, trusty, xenial, bionic
 
 ## RHEL/CentOS
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ deb/rpm repository for Trivy
 ```
 $ apt-get install wget apt-transport-https gnupg
 $ wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | gpg --dearmor | sudo tee /usr/share/keyrings/trivy.gpg > /dev/null
-$ echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb common main" | sudo tee -a /etc/apt/sources.list.d/trivy.list
+$ echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb generic main" | sudo tee -a /etc/apt/sources.list.d/trivy.list
 $ sudo apt-get update
 $ sudo apt-get install trivy
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ deb/rpm repository for Trivy
 ## Debian/Ubuntu
 
 ```
-$ apt-get install wget apt-transport-https gnupg
+$ sudo apt-get install wget apt-transport-https gnupg
 $ wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | gpg --dearmor | sudo tee /usr/share/keyrings/trivy.gpg > /dev/null
 $ echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb generic main" | sudo tee -a /etc/apt/sources.list.d/trivy.list
 $ sudo apt-get update

--- a/deb/conf/distributions
+++ b/deb/conf/distributions
@@ -117,3 +117,11 @@ Architectures: i386 amd64 arm64
 Components: main
 Description: Trivy repository
 SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C
+
+Origin: aquasecurity.github.io/trivy-repo/deb
+Label: github.io/aquasecurity
+Codename: common
+Architectures: i386 amd64 arm64
+Components: main
+Description: Trivy repository
+SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C

--- a/deb/conf/distributions
+++ b/deb/conf/distributions
@@ -136,7 +136,7 @@ SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C
 
 Origin: aquasecurity.github.io/trivy-repo/deb
 Label: github.io/aquasecurity
-Codename: common
+Codename: generic
 Architectures: i386 amd64 arm64
 Components: main
 Description: Trivy repository


### PR DESCRIPTION
## Description
We use same deb packages for every Ubuntu/Debian version.
e.g. you can install Trivy on Ubuntu 22.04 using `bookworm` dir.
```
root@6ea9f26f4810:/# cat /etc/os-release 
PRETTY_NAME="Ubuntu 22.04.3 LTS"
NAME="Ubuntu"
VERSION_ID="22.04"
VERSION="22.04.3 LTS (Jammy Jellyfish)"
VERSION_CODENAME=jammy
...

root@6ea9f26f4810:/# cat /etc/apt/sources.list.d/trivy.list
deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb bookworm main

root@6ea9f26f4810:/# apt-get install trivy
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
...
Unpacking trivy (0.50.2) ...
Setting up trivy (0.50.2) ...
```

This way we can use a `common` folder for all Ubuntu/Debian releases.