### PR TITLE
docs: Update the deb and rpm setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ deb/rpm repository for Trivy
 
 ```
 $ sudo apt-get install wget apt-transport-https gnupg
-$ wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | gpg --dearmor | sudo tee /usr/share/keyrings/trivy.gpg > /dev/null
-$ echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb generic main" | sudo tee -a /etc/apt/sources.list.d/trivy.list
+$ wget -qO - https://get.trivy.dev/deb/public.key | gpg --dearmor | sudo tee /usr/share/keyrings/trivy.gpg > /dev/null
+$ echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://get.trivy.dev/deb generic main" | sudo tee -a /etc/apt/sources.list.d/trivy.list
 $ sudo apt-get update
 $ sudo apt-get install trivy
 ```
@@ -22,7 +22,7 @@ name=Trivy repository
 baseurl=https://aquasecurity.github.io/trivy-repo/rpm/releases/$basearch/
 gpgcheck=1
 enabled=1
-gpgkey=https://aquasecurity.github.io/trivy-repo/rpm/public.key
+gpgkey=https://get.trivy.dev/rpm/public.key
 EOF
 ```
 Using `yum`:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Add repository setting
 $ sudo tee /etc/yum.repos.d/trivy.repo << 'EOF'
 [trivy]
 name=Trivy repository
-baseurl=https://aquasecurity.github.io/trivy-repo/rpm/releases/$basearch/
+baseurl=https://get.trivy.dev/rpm/releases/$basearch/
 gpgcheck=1
 enabled=1
 gpgkey=https://get.trivy.dev/rpm/public.key


### PR DESCRIPTION
Update the steps for the deb configuration to use the get.trivy.dev proxy service

Checking where the installation is going to come from


## RPM 

```
$ dnf repoquery --location trivy

Updating and loading repositories:
Repositories loaded.
https://fedora.mirrorservice.org/fedora/linux/releases/42/Everything/aarch64/os/Packages/t/trivy-0.60.0-1.fc42.aarch64.rpm
https://fedora.mirrorservice.org/fedora/linux/updates/42/Everything/aarch64/Packages/t/trivy-0.63.0-1.fc42.aarch64.rpm
https://get.trivy.dev/rpm/v0.64.1/trivy_0.64.1_Linux-ARM64.rpm <------------------
```

Installing successfully
```
$ dnf install -y --repo=trivy trivy

Importing OpenPGP key 0x6276FA6C:
 UserID     : "trivy"
 Fingerprint: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C
 From       : https://get.trivy.dev/rpm/public.key
Is this ok [y/N]: y
The key was successfully imported.
[1/3] Verify package files                                                                                                                                                                                            100% |  31.0   B/s |   1.0   B |  00m00s
[2/3] Prepare transaction                                                                                                                                                                                             100% | 500.0   B/s |   1.0   B |  00m00s
[3/3] Installing trivy-0:0.64.1-1.aarch64 
```

Verifying installed successfully
```
$ trivy -v

Version: 0.64.1
```
