### PR TITLE
feat(ci): add deploy-packages workflow

### DIFF
--- a/.github/workflows/deploy-packages.yml
+++ b/.github/workflows/deploy-packages.yml
@@ -1,0 +1,135 @@
+name: Deploy Packages
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Trivy release version, e.g. v0.60.0'
+        required: true
+        type: string
+
+permissions: {}  # all GITHUB_TOKEN permissions denied; workflow uses only ORG_REPO_TOKEN
+
+concurrency:
+  group: deploy-packages
+  cancel-in-progress: false  # never cancel an in-progress deployment
+
+jobs:
+  deploy-packages:
+    name: Deploy rpm/deb packages
+    # TODO: change runner to ubuntu-2404-2core
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout trivy-repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          # TODO: ORG_REPO_TOKEN will be renamed to a dedicated secret.
+          # Required fine-grained PAT permissions:
+          #   resource: aquasecurity/trivy-repo — Contents: Write (for git push)
+          token: ${{ secrets.ORG_REPO_TOKEN }}
+          persist-credentials: true
+
+      - name: Setup git settings
+        run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get -y update
+          sudo apt-get -y install rpm reprepro createrepo-c distro-info
+
+      - name: Download release assets
+        env:
+          # TODO: ORG_REPO_TOKEN will be renamed to a dedicated secret.
+          # Required fine-grained PAT permissions:
+          #   aquasecurity/trivy is public — no explicit permissions needed,
+          #   token is used only to avoid unauthenticated API rate limits
+          GH_TOKEN: ${{ secrets.ORG_REPO_TOKEN }}
+          TRIVY_VERSION: ${{ inputs.version }}
+        run: |
+          gh release download "$TRIVY_VERSION" \
+            --repo aquasecurity/trivy \
+            --pattern "*.rpm" --pattern "*.deb" \
+            --dir dist/
+
+      - name: Create RPM repository
+        env:
+          TRIVY_VERSION: ${{ inputs.version }}
+        run: |
+          function create_common_rpm_repo() {
+            local rpm_path=$1
+            local ARCHES=("x86_64" "aarch64")
+            for arch in "${ARCHES[@]}"; do
+              local prefix=$arch
+              if [ "$arch" == "x86_64" ]; then
+                prefix="64bit"
+              elif [ "$arch" == "aarch64" ]; then
+                prefix="ARM64"
+              fi
+              mkdir -p "${rpm_path}/${arch}"
+              cp dist/*${prefix}.rpm "${rpm_path}/${arch}/"
+              createrepo_c -u https://get.trivy.dev/rpm/ --location-prefix="$TRIVY_VERSION" --update "${rpm_path}/${arch}"
+              rm "${rpm_path}/${arch}/"*${prefix}.rpm
+            done
+          }
+
+          function create_rpm_repo() {
+            local version=$1
+            local rpm_path="rpm/releases/${version}/x86_64"
+            mkdir -p "${rpm_path}"
+            cp dist/*64bit.rpm "${rpm_path}/"
+            createrepo_c -u https://get.trivy.dev/rpm/ --location-prefix="$TRIVY_VERSION" --update "${rpm_path}"
+            rm "${rpm_path}/"*64bit.rpm
+          }
+
+          echo "Create RPM releases for Trivy $TRIVY_VERSION"
+
+          echo "Processing common repository for RHEL/CentOS..."
+          create_common_rpm_repo rpm/releases
+
+          VERSIONS=(5 6 7 8 9)
+          for version in "${VERSIONS[@]}"; do
+            echo "Processing RHEL/CentOS ${version}..."
+            create_rpm_repo "${version}"
+          done
+
+      - name: Commit and push RPM changes
+        env:
+          TRIVY_VERSION: ${{ inputs.version }}
+        run: |
+          git add .
+          git commit -m "Update rpm packages for Trivy $TRIVY_VERSION"
+          git push origin main
+
+      - name: Import GPG key
+        env:
+          GPG_KEY: ${{ secrets.GPG_KEY }}
+        run: echo -e "$GPG_KEY" | gpg --import
+
+      - name: Create DEB repository
+        run: |
+          DEBIAN_RELEASES=$(debian-distro-info --supported)
+          UBUNTU_RELEASES=$(sort -u <(ubuntu-distro-info --supported-esm) <(ubuntu-distro-info --supported))
+
+          cd deb
+
+          for release in generic ${DEBIAN_RELEASES[@]} ${UBUNTU_RELEASES[@]}; do
+            echo "Removing deb package of $release"
+            reprepro -A i386 remove $release trivy
+            reprepro -A amd64 remove $release trivy
+            reprepro -A arm64 remove $release trivy
+          done
+
+          for release in generic ${DEBIAN_RELEASES[@]} ${UBUNTU_RELEASES[@]}; do
+            echo "Adding deb package to $release"
+            reprepro includedeb $release ../dist/*Linux-32bit.deb
+            reprepro includedeb $release ../dist/*Linux-64bit.deb
+            reprepro includedeb $release ../dist/*Linux-ARM64.deb
+          done
+
+      - name: Commit and push DEB changes
+        run: |
+          git add .
+          git commit -m "Update deb packages"
+          git push origin main

--- a/.github/workflows/deploy-packages.yml
+++ b/.github/workflows/deploy-packages.yml
@@ -49,7 +49,7 @@ jobs:
           TRIVY_VERSION: ${{ inputs.version }}
         run: |
           gh release download "$TRIVY_VERSION" \
-            --repo aquasecurity/trivy \
+            --repo "$GITHUB_REPOSITORY_OWNER/trivy" \
             --pattern "*.rpm" --pattern "*.deb" \
             --dir dist/
 

--- a/.github/workflows/deploy-packages.yml
+++ b/.github/workflows/deploy-packages.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Trivy release version, e.g. v0.60.0'
+        description: 'Trivy release version with v prefix, e.g. v0.60.0'
         required: true
         type: string
 

--- a/.github/workflows/deploy-packages.yml
+++ b/.github/workflows/deploy-packages.yml
@@ -38,8 +38,8 @@ jobs:
 
       - name: Download release assets
         env:
-          # aquasecurity/trivy is public; token is used only to avoid unauthenticated API rate limits
-          GH_TOKEN: ${{ secrets.TRIVY_REPO_DEPLOY_TOKEN }}
+          # aquasecurity/trivy is public; GITHUB_TOKEN is used only to raise the API rate limit
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TRIVY_VERSION: ${{ inputs.version }}
         run: |
           gh release download "$TRIVY_VERSION" \

--- a/.github/workflows/deploy-packages.yml
+++ b/.github/workflows/deploy-packages.yml
@@ -56,51 +56,7 @@ jobs:
       - name: Create RPM repository
         env:
           TRIVY_VERSION: ${{ inputs.version }}
-        run: |
-          function create_common_rpm_repo() {
-            local rpm_path=$1
-            local ARCHES=("x86_64" "aarch64")
-            for arch in "${ARCHES[@]}"; do
-              local prefix=$arch
-              if [ "$arch" == "x86_64" ]; then
-                prefix="64bit"
-              elif [ "$arch" == "aarch64" ]; then
-                prefix="ARM64"
-              fi
-              mkdir -p "${rpm_path}/${arch}"
-              cp dist/*${prefix}.rpm "${rpm_path}/${arch}/"
-              createrepo_c -u https://get.trivy.dev/rpm/ --location-prefix="$TRIVY_VERSION" --update "${rpm_path}/${arch}"
-              rm "${rpm_path}/${arch}/"*${prefix}.rpm
-            done
-          }
-
-          function create_rpm_repo() {
-            local version=$1
-            local rpm_path="rpm/releases/${version}/x86_64"
-            mkdir -p "${rpm_path}"
-            cp dist/*64bit.rpm "${rpm_path}/"
-            createrepo_c -u https://get.trivy.dev/rpm/ --location-prefix="$TRIVY_VERSION" --update "${rpm_path}"
-            rm "${rpm_path}/"*64bit.rpm
-          }
-
-          echo "Create RPM releases for Trivy $TRIVY_VERSION"
-
-          echo "Processing common repository for RHEL/CentOS..."
-          create_common_rpm_repo rpm/releases
-
-          VERSIONS=(5 6 7 8 9)
-          for version in "${VERSIONS[@]}"; do
-            echo "Processing RHEL/CentOS ${version}..."
-            create_rpm_repo "${version}"
-          done
-
-      - name: Commit and push RPM changes
-        env:
-          TRIVY_VERSION: ${{ inputs.version }}
-        run: |
-          git add .
-          git commit -m "Update rpm packages for Trivy $TRIVY_VERSION"
-          git push origin main
+        run: ci/deploy-rpm.sh "$TRIVY_VERSION"
 
       - name: Import GPG key
         env:
@@ -108,28 +64,4 @@ jobs:
         run: echo -e "$GPG_KEY" | gpg --import
 
       - name: Create DEB repository
-        run: |
-          DEBIAN_RELEASES=$(debian-distro-info --supported)
-          UBUNTU_RELEASES=$(sort -u <(ubuntu-distro-info --supported-esm) <(ubuntu-distro-info --supported))
-
-          cd deb
-
-          for release in generic ${DEBIAN_RELEASES[@]} ${UBUNTU_RELEASES[@]}; do
-            echo "Removing deb package of $release"
-            reprepro -A i386 remove $release trivy
-            reprepro -A amd64 remove $release trivy
-            reprepro -A arm64 remove $release trivy
-          done
-
-          for release in generic ${DEBIAN_RELEASES[@]} ${UBUNTU_RELEASES[@]}; do
-            echo "Adding deb package to $release"
-            reprepro includedeb $release ../dist/*Linux-32bit.deb
-            reprepro includedeb $release ../dist/*Linux-64bit.deb
-            reprepro includedeb $release ../dist/*Linux-ARM64.deb
-          done
-
-      - name: Commit and push DEB changes
-        run: |
-          git add .
-          git commit -m "Update deb packages"
-          git push origin main
+        run: ci/deploy-deb.sh

--- a/.github/workflows/deploy-packages.yml
+++ b/.github/workflows/deploy-packages.yml
@@ -17,8 +17,7 @@ concurrency:
 jobs:
   deploy-packages:
     name: Deploy rpm/deb packages
-    # TODO: change runner to ubuntu-2404-2core
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-2404-2core
     steps:
       - name: Checkout trivy-repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/deploy-packages.yml
+++ b/.github/workflows/deploy-packages.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
 
-permissions: {}  # all GITHUB_TOKEN permissions denied; workflow uses only ORG_REPO_TOKEN
+permissions: {}  # all GITHUB_TOKEN permissions denied; workflow uses only TRIVY_REPO_DEPLOY_TOKEN
 
 concurrency:
   group: deploy-packages
@@ -23,10 +23,7 @@ jobs:
       - name: Checkout trivy-repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          # TODO: ORG_REPO_TOKEN will be renamed to a dedicated secret.
-          # Required fine-grained PAT permissions:
-          #   resource: aquasecurity/trivy-repo — Contents: Write (for git push)
-          token: ${{ secrets.ORG_REPO_TOKEN }}
+          token: ${{ secrets.TRIVY_REPO_DEPLOY_TOKEN }}
           persist-credentials: true
 
       - name: Setup git settings
@@ -41,11 +38,8 @@ jobs:
 
       - name: Download release assets
         env:
-          # TODO: ORG_REPO_TOKEN will be renamed to a dedicated secret.
-          # Required fine-grained PAT permissions:
-          #   aquasecurity/trivy is public — no explicit permissions needed,
-          #   token is used only to avoid unauthenticated API rate limits
-          GH_TOKEN: ${{ secrets.ORG_REPO_TOKEN }}
+          # aquasecurity/trivy is public; token is used only to avoid unauthenticated API rate limits
+          GH_TOKEN: ${{ secrets.TRIVY_REPO_DEPLOY_TOKEN }}
           TRIVY_VERSION: ${{ inputs.version }}
         run: |
           gh release download "$TRIVY_VERSION" \

--- a/ci/deploy-deb.sh
+++ b/ci/deploy-deb.sh
@@ -2,7 +2,10 @@
 
 set -eu
 
-DEBIAN_RELEASES=$(debian-distro-info --supported)
+# "sid" and "experimental" are Debian pseudo-distributions, not stable releases.
+# They are included in `debian-distro-info --supported` output but have no reprepro
+# distributions entry and are not meaningful targets for a package repository.
+DEBIAN_RELEASES=$(debian-distro-info --supported | grep -vE "^(experimental|sid)$")
 UBUNTU_RELEASES=$(sort -u <(ubuntu-distro-info --supported-esm) <(ubuntu-distro-info --supported))
 
 cd deb

--- a/ci/deploy-deb.sh
+++ b/ci/deploy-deb.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -eu
+
+DEBIAN_RELEASES=$(debian-distro-info --supported)
+UBUNTU_RELEASES=$(sort -u <(ubuntu-distro-info --supported-esm) <(ubuntu-distro-info --supported))
+
+cd deb
+
+for release in generic ${DEBIAN_RELEASES[@]} ${UBUNTU_RELEASES[@]}; do
+  echo "Removing deb package of $release"
+  reprepro -A i386 remove $release trivy
+  reprepro -A amd64 remove $release trivy
+  reprepro -A arm64 remove $release trivy
+done
+
+for release in generic ${DEBIAN_RELEASES[@]} ${UBUNTU_RELEASES[@]}; do
+  echo "Adding deb package to $release"
+  reprepro includedeb $release ../dist/*Linux-32bit.deb
+  reprepro includedeb $release ../dist/*Linux-64bit.deb
+  reprepro includedeb $release ../dist/*Linux-ARM64.deb
+done
+
+git add .
+git commit -m "Update deb packages"
+git push origin main

--- a/ci/deploy-rpm.sh
+++ b/ci/deploy-rpm.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -eu
+
+TRIVY_VERSION=$1
+
+function create_common_rpm_repo() {
+  rpm_path=$1
+
+  ARCHES=("x86_64" "aarch64")
+  for arch in "${ARCHES[@]}"; do
+    prefix=$arch
+    if [ "$arch" == "x86_64" ]; then
+      prefix="64bit"
+    elif [ "$arch" == "aarch64" ]; then
+      prefix="ARM64"
+    fi
+    mkdir -p "${rpm_path}/${arch}"
+    cp dist/*${prefix}.rpm "${rpm_path}/${arch}/"
+    createrepo_c -u https://get.trivy.dev/rpm/ --location-prefix="${TRIVY_VERSION}" --update "${rpm_path}/${arch}"
+    rm "${rpm_path}/${arch}/"*${prefix}.rpm
+  done
+}
+
+function create_rpm_repo() {
+  version=$1
+  rpm_path="rpm/releases/${version}/x86_64"
+
+  mkdir -p "${rpm_path}"
+  cp dist/*64bit.rpm "${rpm_path}/"
+  createrepo_c -u https://get.trivy.dev/rpm/ --location-prefix="${TRIVY_VERSION}" --update "${rpm_path}"
+  rm "${rpm_path}/"*64bit.rpm
+}
+
+echo "Create RPM releases for Trivy ${TRIVY_VERSION}"
+
+echo "Processing common repository for RHEL/CentOS..."
+create_common_rpm_repo rpm/releases
+
+VERSIONS=(5 6 7 8 9)
+for version in "${VERSIONS[@]}"; do
+  echo "Processing RHEL/CentOS ${version}..."
+  create_rpm_repo "${version}"
+done
+
+git add .
+git commit -m "Update rpm packages for Trivy ${TRIVY_VERSION}"
+git push origin main

--- a/deb/conf/distributions
+++ b/deb/conf/distributions
@@ -76,7 +76,7 @@ Codename: trixie
 Architectures: i386 amd64 arm64
 Components: main
 Description: Trivy repository
-SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C.
+SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C
 
 Origin: aquasecurity.github.io/trivy-repo/deb
 Label: github.io/aquasecurity
@@ -84,7 +84,7 @@ Codename: forky
 Architectures: i386 amd64 arm64
 Components: main
 Description: Trivy repository
-SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C.
+SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C
 
 Origin: aquasecurity.github.io/trivy-repo/deb
 Label: github.io/aquasecurity
@@ -156,7 +156,7 @@ Codename: questing
 Architectures: i386 amd64 arm64
 Components: main
 Description: Trivy repository
-SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C.
+SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C
 
 Origin: aquasecurity.github.io/trivy-repo/deb
 Label: github.io/aquasecurity
@@ -164,7 +164,7 @@ Codename: resolute
 Architectures: i386 amd64 arm64
 Components: main
 Description: Trivy repository
-SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C.
+SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C
 
 Origin: aquasecurity.github.io/trivy-repo/deb
 Label: github.io/aquasecurity

--- a/deb/conf/distributions
+++ b/deb/conf/distributions
@@ -72,6 +72,22 @@ SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C
 
 Origin: aquasecurity.github.io/trivy-repo/deb
 Label: github.io/aquasecurity
+Codename: trixie
+Architectures: i386 amd64 arm64
+Components: main
+Description: Trivy repository
+SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C.
+
+Origin: aquasecurity.github.io/trivy-repo/deb
+Label: github.io/aquasecurity
+Codename: forky
+Architectures: i386 amd64 arm64
+Components: main
+Description: Trivy repository
+SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C.
+
+Origin: aquasecurity.github.io/trivy-repo/deb
+Label: github.io/aquasecurity
 Codename: trusty
 Architectures: i386 amd64 arm64
 Components: main
@@ -133,6 +149,22 @@ Architectures: i386 amd64 arm64
 Components: main
 Description: Trivy repository
 SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C
+
+Origin: aquasecurity.github.io/trivy-repo/deb
+Label: github.io/aquasecurity
+Codename: questing
+Architectures: i386 amd64 arm64
+Components: main
+Description: Trivy repository
+SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C.
+
+Origin: aquasecurity.github.io/trivy-repo/deb
+Label: github.io/aquasecurity
+Codename: resolute
+Architectures: i386 amd64 arm64
+Components: main
+Description: Trivy repository
+SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C.
 
 Origin: aquasecurity.github.io/trivy-repo/deb
 Label: github.io/aquasecurity


### PR DESCRIPTION
## Description                                                                                                                                                                                                                                     
Extracts the deploy-packages job from the aquasecurity/trivy release pipeline into a standalone workflow_dispatch workflow living in this repo. Previously, deploying RPM/DEB packages required a full checkout of the trivy repo and cross-repo cache access. Now trivy simply fires gh workflow run and this repo handles the rest autonomously.                                                                                                                                              
                  
## Changes                                                                                                                                                                                                                                         
  - .github/workflows/deploy-packages.yml — new workflow_dispatch workflow; accepts version input, downloads .rpm/.deb assets from the trivy GitHub Release, rebuilds RPM and DEB repositories, and pushes to main                                
  - ci/deploy-rpm.sh — RPM repo creation logic for x86_64/aarch64 across common and RHEL 5–9 versioned paths
  - ci/deploy-deb.sh — DEB repo update via reprepro for all supported Debian/Ubuntu releases; excludes sid/experimental pseudo-distributions                                                                                                      
  - deb/conf/distributions — adds missing entries: trixie, forky (Debian) and questing, resolute (Ubuntu)     

## Checks

- Verified with `zizmor`: no findings

## Test
- (trivy workflow) https://github.com/DmitriyLewen/trivy/actions/runs/23939343876/job/69823079993
- (trivy-repo workflow) https://github.com/DmitriyLewen/trivy-repo/actions/runs/23939677292
- trivy-repo commits:
  - https://github.com/DmitriyLewen/trivy-repo/commit/9105ff5c4e6b401d5b8878d38e316b1dec1f11a4
  - https://github.com/DmitriyLewen/trivy-repo/commit/72c349059bff0efe0ba73c89033f2990c7ec79e5

## TODO
- [ ] Replace ORG_REPO_TOKEN with a new one 
- [x] Use a self-hosted runner

## Related PRs
- [ ] https://github.com/aquasecurity/trivy/pull/10476