### PR TITLE
ci: merge RPM repo metadata

### DIFF
--- a/ci/deploy-rpm.sh
+++ b/ci/deploy-rpm.sh
@@ -4,6 +4,45 @@ set -eu
 
 TRIVY_VERSION=$1
 
+# Merge freshly generated repo metadata for new RPMs with existing repo metadata
+# Arguments:
+#   $1 - glob for RPMs to include from ../dist (e.g., "*64bit.rpm")
+#   $2 - target repo path where repodata is maintained (e.g., rpm/releases/7/x86_64)
+function merge_repo_with_new_packages () {
+        rpm_glob=$1
+        rpm_path=$2
+
+        mkdir -p "$rpm_path"
+
+        base_dir=$(dirname "$rpm_path")
+        rpm_tmp="$base_dir/tmp"
+        rpm_old="$base_dir/old"
+
+        mkdir -p "$rpm_tmp"
+        mkdir -p "$rpm_old"
+
+        # stage new packages in a temp directory
+        cp dist/${rpm_glob} "$rpm_tmp"/
+
+        # generate metadata for the staged packages only
+        createrepo_c -u https://get.trivy.dev/rpm/ --location-prefix="$TRIVY_VERSION" --update "$rpm_tmp"
+
+        if [ -d "$rpm_path/repodata" ]; then
+                # Preserve existing metadata by merging with new repo metadata
+                cp -r "$rpm_path/repodata" "$rpm_old"/
+                mergerepo_c -v --all -r "$rpm_old" -r "$rpm_tmp" -o "$rpm_path"
+        else
+                # No existing repo: initialize from the new metadata
+                cp -r "$rpm_tmp/repodata" "$rpm_path"/
+        fi
+
+        rm -rf "$rpm_tmp"
+        rm -rf "$rpm_old"
+
+        # ensure no RPM files remain in the target repo path
+        rm -f "$rpm_path"/*.rpm || true
+}
+
 function create_common_rpm_repo() {
   rpm_path=$1
 
@@ -15,10 +54,8 @@ function create_common_rpm_repo() {
     elif [ "$arch" == "aarch64" ]; then
       prefix="ARM64"
     fi
-    mkdir -p "${rpm_path}/${arch}"
-    cp dist/*${prefix}.rpm "${rpm_path}/${arch}/"
-    createrepo_c -u https://get.trivy.dev/rpm/ --location-prefix="${TRIVY_VERSION}" --update "${rpm_path}/${arch}"
-    rm "${rpm_path}/${arch}/"*${prefix}.rpm
+
+    merge_repo_with_new_packages "*${prefix}.rpm" "$rpm_path/$arch"
   done
 }
 
@@ -26,10 +63,7 @@ function create_rpm_repo() {
   version=$1
   rpm_path="rpm/releases/${version}/x86_64"
 
-  mkdir -p "${rpm_path}"
-  cp dist/*64bit.rpm "${rpm_path}/"
-  createrepo_c -u https://get.trivy.dev/rpm/ --location-prefix="${TRIVY_VERSION}" --update "${rpm_path}"
-  rm "${rpm_path}/"*64bit.rpm
+  merge_repo_with_new_packages "*64bit.rpm" "$rpm_path"
 }
 
 echo "Create RPM releases for Trivy ${TRIVY_VERSION}"

--- a/ci/deploy-rpm.sh
+++ b/ci/deploy-rpm.sh
@@ -9,8 +9,8 @@ TRIVY_VERSION=$1
 #   $1 - glob for RPMs to include from ../dist (e.g., "*64bit.rpm")
 #   $2 - target repo path where repodata is maintained (e.g., rpm/releases/7/x86_64)
 function merge_repo_with_new_packages () {
-        rpm_glob=$1
-        rpm_path=$2
+        local rpm_glob=$1
+        local rpm_path=$2
 
         mkdir -p "$rpm_path"
 
@@ -44,7 +44,7 @@ function merge_repo_with_new_packages () {
 }
 
 function create_common_rpm_repo() {
-  rpm_path=$1
+  local rpm_path=$1
 
   ARCHES=("x86_64" "aarch64")
   for arch in "${ARCHES[@]}"; do

--- a/ci/deploy-rpm.sh
+++ b/ci/deploy-rpm.sh
@@ -11,6 +11,7 @@ TRIVY_VERSION=$1
 function merge_repo_with_new_packages () {
   local rpm_glob=$1
   local rpm_path=$2
+  local base_dir rpm_tmp rpm_old
 
   mkdir -p "$rpm_path"
 
@@ -45,8 +46,8 @@ function merge_repo_with_new_packages () {
 
 function create_common_rpm_repo() {
   local rpm_path=$1
-
-  ARCHES=("x86_64" "aarch64")
+  local -a ARCHES=("x86_64" "aarch64")
+  local arch prefix
   for arch in "${ARCHES[@]}"; do
     prefix=$arch
     if [ "$arch" == "x86_64" ]; then
@@ -60,8 +61,8 @@ function create_common_rpm_repo() {
 }
 
 function create_rpm_repo() {
-  version=$1
-  rpm_path="rpm/releases/${version}/x86_64"
+  local version=$1
+  local rpm_path="rpm/releases/${version}/x86_64"
 
   merge_repo_with_new_packages "*64bit.rpm" "$rpm_path"
 }

--- a/ci/deploy-rpm.sh
+++ b/ci/deploy-rpm.sh
@@ -9,38 +9,38 @@ TRIVY_VERSION=$1
 #   $1 - glob for RPMs to include from ../dist (e.g., "*64bit.rpm")
 #   $2 - target repo path where repodata is maintained (e.g., rpm/releases/7/x86_64)
 function merge_repo_with_new_packages () {
-        local rpm_glob=$1
-        local rpm_path=$2
+  local rpm_glob=$1
+  local rpm_path=$2
 
-        mkdir -p "$rpm_path"
+  mkdir -p "$rpm_path"
 
-        base_dir=$(dirname "$rpm_path")
-        rpm_tmp="$base_dir/tmp"
-        rpm_old="$base_dir/old"
+  base_dir=$(dirname "$rpm_path")
+  rpm_tmp="$base_dir/tmp"
+  rpm_old="$base_dir/old"
 
-        mkdir -p "$rpm_tmp"
-        mkdir -p "$rpm_old"
+  mkdir -p "$rpm_tmp"
+  mkdir -p "$rpm_old"
 
-        # stage new packages in a temp directory
-        cp dist/${rpm_glob} "$rpm_tmp"/
+  # stage new packages in a temp directory
+  cp dist/${rpm_glob} "$rpm_tmp"/
 
-        # generate metadata for the staged packages only
-        createrepo_c -u https://get.trivy.dev/rpm/ --location-prefix="$TRIVY_VERSION" --update "$rpm_tmp"
+  # generate metadata for the staged packages only
+  createrepo_c -u https://get.trivy.dev/rpm/ --location-prefix="$TRIVY_VERSION" --update "$rpm_tmp"
 
-        if [ -d "$rpm_path/repodata" ]; then
-                # Preserve existing metadata by merging with new repo metadata
-                cp -r "$rpm_path/repodata" "$rpm_old"/
-                mergerepo_c -v --all -r "$rpm_old" -r "$rpm_tmp" -o "$rpm_path"
-        else
-                # No existing repo: initialize from the new metadata
-                cp -r "$rpm_tmp/repodata" "$rpm_path"/
-        fi
+  if [ -d "$rpm_path/repodata" ]; then
+    # Preserve existing metadata by merging with new repo metadata
+    cp -r "$rpm_path/repodata" "$rpm_old"/
+    mergerepo_c -v --all -r "$rpm_old" -r "$rpm_tmp" -o "$rpm_path"
+  else
+    # No existing repo: initialize from the new metadata
+    cp -r "$rpm_tmp/repodata" "$rpm_path"/
+  fi
 
-        rm -rf "$rpm_tmp"
-        rm -rf "$rpm_old"
+  rm -rf "$rpm_tmp"
+  rm -rf "$rpm_old"
 
-        # ensure no RPM files remain in the target repo path
-        rm -f "$rpm_path"/*.rpm || true
+  # ensure no RPM files remain in the target repo path
+  rm -f "$rpm_path"/*.rpm || true
 }
 
 function create_common_rpm_repo() {


### PR DESCRIPTION
## Description
This PR merges RPM repo metadata instead of rebuilding from scratch.

## Testing
it was tested in the fork https://github.com/afdesk/trivy-repo
- the fork already contained Trivy v0.69.3, so it built the second repo with v0.69.2: https://github.com/afdesk/trivy-repo/commit/68f79d33fd167b9e60f2fc233c1b775b78090bfc

then it was published in a custom github org here: https://github.com/trivy-repo-dev/trivy-repo-dev.github.io to use on `almalinux:10` instance:
```sh
% docker run -it --rm almalinux:10
[root@fce931eb938f /]# yum -y update
[root@fce931eb938f /]# yum -y install nano
[root@fce931eb938f /]# nano /etc/yum.repos.d/trivy.repo
[root@fce931eb938f /]# yum -y update
Trivy TEST repository                                                                                                                  874  B/s | 697  B     00:00    
Dependencies resolved.
Nothing to do.
Complete!
[root@2e255d17d982 /]#  yum --showduplicates list trivy
Last metadata expiration check: 0:00:11 ago on Wed Apr  8 09:25:20 2026.
Available Packages
trivy.aarch64                                                                      0.69.2-1                                                                       trivy
trivy.aarch64                                                                      0.69.3-1                                                                       trivy
[root@2e255d17d982 /]# yum -y install trivy-0.69.2
...
[root@2e255d17d982 /]# trivy -v
Version: 0.69.2
[root@2e255d17d982 /]# yum -y install trivy-0.69.3
...
[root@2e255d17d982 /]# trivy -v
Version: 0.69.3
```

Notes:
* we don't need to install `mergerepo_c` separately, it's a part of `createrepo_c` package:
```sh
# dpkg -L createrepo-c | grep mergerepo_c
/usr/bin/mergerepo_c
/usr/share/man/man8/mergerepo_c.8.gz
/usr/share/bash-completion/completions/mergerepo_c
```

## Related issues
- Close https://github.com/aquasecurity/trivy-repo/issues/44
