### PR TITLE
fix(ci): limit git add to package directories to avoid committing dist/

### DIFF
--- a/ci/deploy-deb.sh
+++ b/ci/deploy-deb.sh
@@ -24,6 +24,7 @@ for release in generic ${DEBIAN_RELEASES[@]} ${UBUNTU_RELEASES[@]}; do
   reprepro includedeb $release ../dist/*Linux-ARM64.deb
 done
 
+# git runs inside `deb/`, so "git add ." stages only `deb/` contents.
 git add .
 git commit -m "Update deb packages"
 git push origin main

--- a/ci/deploy-rpm.sh
+++ b/ci/deploy-rpm.sh
@@ -43,6 +43,6 @@ for version in "${VERSIONS[@]}"; do
   create_rpm_repo "${version}"
 done
 
-git add .
+git add rpm/
 git commit -m "Update rpm packages for Trivy ${TRIVY_VERSION}"
 git push origin main


### PR DESCRIPTION
## Summary
After moving deploy scripts into this repo (#47), `git add .` in `deploy-rpm.sh` stages the
`dist/` directory (downloaded .rpm/.deb release assets) and pushes it to the repository.

### Changes
- `deploy-rpm.sh`: `git add .` → `git add rpm/`
- `deploy-deb.sh`: added a comment clarifying that `git add .` runs inside `deb/` (after `cd deb`),
  so it only stages `deb/` contents

### Evidence of the bug
Commits where `dist/` was accidentally pushed:
- [`9105ff5`](https://github.com/DmitriyLewen/trivy-repo/commit/9105ff5) — Update rpm packages for Trivy v0.999.1
- [`692cfe4`](https://github.com/DmitriyLewen/trivy-repo/commit/692cfe4) — Update rpm packages for Trivy v0.999.2
- [`da88dda`](https://github.com/DmitriyLewen/trivy-repo/commit/da88dda) — Update rpm packages for Trivy v0.999.3

Workflow runs that produced these commits:
- [Run 23939677292](https://github.com/DmitriyLewen/trivy-repo/actions/runs/23939677292) (v0.999.1)
- [Run 23943636159](https://github.com/DmitriyLewen/trivy-repo/actions/runs/23943636159) (v0.999.2)
- [Run 24028502624](https://github.com/DmitriyLewen/trivy-repo/actions/runs/24028502624) (v0.999.3)

Manual cleanup: [`cb66026`](https://github.com/DmitriyLewen/trivy-repo/commit/cb66026) — fix: remove dist dir.

### Verification
After the fix, `dist/` is no longer committed:
- [Run 24122356512](https://github.com/DmitriyLewen/trivy-repo/actions/runs/24122356512) (v0.999.4)
- [`cee0da3`](https://github.com/DmitriyLewen/trivy-repo/commit/cee0da3f22b4535775842f8be4c7713adf2b86bc) — Update rpm packages (no dist/)
- [`8dd30f4`](https://github.com/DmitriyLewen/trivy-repo/commit/8dd30f4fb1556d4be0344815af21436dbcbb45cb) — Update deb packages (no dist/)