### PR TITLE
ci: add gpg flags --batch and --no-tty

### DIFF
--- a/.github/workflows/deploy-packages.yml
+++ b/.github/workflows/deploy-packages.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Import GPG key
         env:
           GPG_KEY: ${{ secrets.GPG_KEY }}
-        run: echo -e "$GPG_KEY" | gpg --import
+        run: echo -e "$GPG_KEY" | gpg --import --batch --no-tty
 
       - name: Create DEB repository
         run: ci/deploy-deb.sh


### PR DESCRIPTION
## Description 

This PR adds `--batch` and `--no-tty` flags for `gpg` command.

It seems there was updated OS after migration #47. and it got an error with a terminal: `Inappropriate ioctl for device`. 

Before this PR (https://github.com/afdesk/trivy-repo/actions/runs/24492024850/job/71578803200):
```sh
Run echo -e "$GPG_KEY" | gpg --import
gpg: directory '/home/runner/.gnupg' created
gpg: keybox '/home/runner/.gnupg/pubring.kbx' created
gpg: /home/runner/.gnupg/trustdb.gpg: trustdb created
gpg: key 81E47D73BC0F7B30: public key "trivy-repo-test <amf@afdesk.com>" imported
gpg: key 81E47D73BC0F7B30/81E47D73BC0F7B30: error sending to agent: Inappropriate ioctl for device
gpg: error building skey array: Inappropriate ioctl for device
gpg: error reading '[stdin]': Inappropriate ioctl for device
gpg: import from '[stdin]' failed: Inappropriate ioctl for device
gpg: Total number processed: 0
gpg:               imported: 1
gpg:       secret keys read: 1
Error: Process completed with exit code 2.
```
After this PR (https://github.com/afdesk/trivy-repo/actions/runs/24492512694/job/71580198947#step:8:19):
```sh
Run echo -e "$GPG_KEY" | gpg --import --batch --no-tty
gpg: directory '/home/runner/.gnupg' created
gpg: keybox '/home/runner/.gnupg/pubring.kbx' created
gpg: /home/runner/.gnupg/trustdb.gpg: trustdb created
gpg: key 81E47D73BC0F7B30: public key "trivy-repo-test <amf@afdesk.com>" imported
gpg: key 81E47D73BC0F7B30: secret key imported
gpg: Total number processed: 1
gpg:               imported: 1
gpg:       secret keys read: 1
gpg:   secret keys imported: 1
```

```sh
       --batch
       --no-batch
              Use batch mode.  Never ask, do not allow interactive commands.  --no-batch disables this option.  Note that even with a filename given on the command line, gpg might still need
              to read from STDIN (in particular if gpg figures that the input is a detached signature and no data file has been specified).  Thus if you do not want to feed data via STDIN, you
              should connect STDIN to ‘/dev/null’.

              It is highly recommended to use this option along with the options --status-fd and --with-colons for any unattended use of gpg.  Should not be used in an option file.

       --no-tty
              Make sure that the TTY (terminal) is never used for any output.  This option is needed in some cases because GnuPG sometimes prints warnings to the TTY even if --batch is used.
```