### PR TITLE
ci: switch from PAT to GitHub App installation token

### DIFF
--- a/.github/workflows/deploy-packages.yml
+++ b/.github/workflows/deploy-packages.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
 
-permissions: {}  # all GITHUB_TOKEN permissions denied; workflow uses only TRIVY_REPO_DEPLOY_TOKEN
+permissions: {}  # GITHUB_TOKEN has no repo permissions; checkout/push uses a GitHub App installation token
 
 concurrency:
   group: deploy-packages
@@ -19,11 +19,20 @@ jobs:
     name: Deploy rpm/deb packages
     runs-on: ubuntu-2404-2core
     steps:
+      - name: Generate token for trivy-repo
+        id: trivy-repo-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ secrets.REPO_TRIVY_REPO_WRITE_GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.REPO_TRIVY_REPO_WRITE_GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
       - name: Checkout trivy-repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          token: ${{ secrets.TRIVY_REPO_DEPLOY_TOKEN }}
-          persist-credentials: true
+          token: ${{ steps.trivy-repo-token.outputs.token }}
+          persist-credentials: true  # ci/deploy-*.sh runs git push
 
       - name: Setup git settings
         run: |


### PR DESCRIPTION
## Description

Replace the long-lived PAT (`TRIVY_REPO_DEPLOY_TOKEN`) used by `deploy-packages.yml` for the `trivy-repo` checkout/push with a short-lived installation token minted from a GitHub App via [`actions/create-github-app-token`][action] (`v3.1.1`, pinned by SHA). App is authenticated via Client ID (`app-id` input is deprecated upstream, [we use `client-id`][client-id-doc]).

App credentials: `REPO_TRIVY_REPO_WRITE_GH_APP_CLIENT_ID` + `REPO_TRIVY_REPO_WRITE_GH_APP_PRIVATE_KEY`.

The token is requested with the minimum scope needed for the job: write access to a single repository (`aquasecurity/trivy-repo`) under a single owner. The extraheader written by `actions/checkout` (`persist-credentials: true`) is kept because `ci/deploy-deb.sh` and `ci/deploy-rpm.sh` run `git push origin main`.

No token-refresh split is needed: typical runs of this workflow finish in ~2 minutes, well within the 1h installation-token TTL.

[action]: https://github.com/actions/create-github-app-token
[client-id-doc]: https://github.com/actions/create-github-app-token/blob/1b10c78c7865c340bc4f6099eb2f838309f1e8c3/action.yml

## Changes

- Add a `Generate token for trivy-repo` step that exchanges the App credentials for an installation token, scoped to `${{ github.repository_owner }}/${{ github.event.repository.name }}`.
- Replace `token: ${{ secrets.TRIVY_REPO_DEPLOY_TOKEN }}` in the `Checkout trivy-repo` step with `token: ${{ steps.trivy-repo-token.outputs.token }}`.
- Use the `client-id` input (preferred) instead of the deprecated `app-id` input on `actions/create-github-app-token`.
- `actions/create-github-app-token` is pinned by SHA (`v3.1.1`), matching the convention for third-party actions in this workflow.
- Update the workflow-level `permissions: {}` comment to reflect that `GITHUB_TOKEN` is no longer used for checkout/push (it is still used only by `gh release download` to raise the public-API rate limit).

## Required admin actions

- [x] **Add secrets:** `REPO_TRIVY_REPO_WRITE_GH_APP_CLIENT_ID`, `REPO_TRIVY_REPO_WRITE_GH_APP_PRIVATE_KEY`.
- [ ] **Remove (after merge):** `TRIVY_REPO_DEPLOY_TOKEN`.
