### PR TITLE
Add stonking (Ubuntu 26.10) to deb distributions

### DIFF
--- a/deb/conf/distributions
+++ b/deb/conf/distributions
@@ -168,6 +168,14 @@ SignWith: 825AD9036F7C850E6A6FED4935B8ACA44FD9CA9F
 
 Origin: aquasecurity.github.io/trivy-repo/deb
 Label: github.io/aquasecurity
+Codename: stonking
+Architectures: i386 amd64 arm64
+Components: main
+Description: Trivy repository
+SignWith: 825AD9036F7C850E6A6FED4935B8ACA44FD9CA9F
+
+Origin: aquasecurity.github.io/trivy-repo/deb
+Label: github.io/aquasecurity
 Codename: generic
 Architectures: i386 amd64 arm64
 Components: main


### PR DESCRIPTION
## Description

The `Deploy Packages` workflow fails at the **Create DEB repository** step with:

```
Removing deb package of stonking
Cannot find definition of distribution 'stonking'!
There have been errors!
Process completed with exit code 249.
```

A new Ubuntu release **stonking** (26.10) is now returned by `ubuntu-distro-info --supported` on the GitHub runner (after a `distro-info-data` update). `ci/deploy-deb.sh` builds its release list dynamically from `distro-info`, but `deb/conf/distributions` has no `reprepro` entry for `stonking`, so `reprepro` aborts.

This adds the missing `stonking` distribution block, formatted identically to the existing entries.

Failing run: https://github.com/aquasecurity/trivy-repo/actions/runs/26759095047/job/78867167392

## Tests
Run:
- https://github.com/DmitriyLewen/trivy-repo/actions/runs/26760752607
Test rpm installation:
```
➜  ~   docker run --rm -it almalinux:9 bash -c '
  echo "[trivy]" > /etc/yum.repos.d/trivy.repo
  echo "name=Trivy repository" >> /etc/yum.repos.d/trivy.repo
  echo "baseurl=https://raw.githubusercontent.com/DmitriyLewen/trivy-repo/test/deploy-stonking-fork/rpm/releases/\$basearch/" >> /etc/yum.repos.d/trivy.repo
  echo "gpgcheck=1" >> /etc/yum.repos.d/trivy.repo
  echo "enabled=1" >> /etc/yum.repos.d/trivy.repo
  echo "gpgkey=https://raw.githubusercontent.com/DmitriyLewen/trivy-repo/test/deploy-stonking-fork/rpm/public.key" >> /etc/yum.repos.d/trivy.repo
  cat /etc/yum.repos.d/trivy.repo
  yum -y install trivy && trivy --version
  '

[trivy]
name=Trivy repository
baseurl=https://raw.githubusercontent.com/DmitriyLewen/trivy-repo/test/deploy-stonking-fork/rpm/releases/$basearch/
gpgcheck=1
enabled=1
gpgkey=https://raw.githubusercontent.com/DmitriyLewen/trivy-repo/test/deploy-stonking-fork/rpm/public.key
AlmaLinux 9 - AppStream                                                                                                            2.7 MB/s | 9.0 MB     00:03    
AlmaLinux 9 - BaseOS                                                                                                               1.6 MB/s | 3.0 MB     00:01    
AlmaLinux 9 - Extras                                                                                                                14 kB/s |  22 kB     00:01    
Trivy repository                                                                                                                   1.6 kB/s | 980  B     00:00    
Dependencies resolved.
===================================================================================================================================================================
 Package                              Architecture                           Version                                    Repository                            Size
===================================================================================================================================================================
Installing:
 trivy                                aarch64                                0.71.0-1                                   trivy                                 45 M

Transaction Summary
===================================================================================================================================================================
Install  1 Package

Total download size: 45 M
Installed size: 148 M
Downloading Packages:
trivy_0.71.0_Linux-ARM64.rpm                                                                                                       3.2 MB/s |  45 MB     00:13    
-------------------------------------------------------------------------------------------------------------------------------------------------------------------
Total                                                                                                                              3.2 MB/s |  45 MB     00:13     
Trivy repository                                                                                                                   5.4 kB/s | 1.6 kB     00:00    
Importing GPG key 0x4FD9CA9F:
 Userid     : "trivy-repo <oss@aquasec.com>"
 Fingerprint: 825A D903 6F7C 850E 6A6F ED49 35B8 ACA4 4FD9 CA9F
 From       : https://raw.githubusercontent.com/DmitriyLewen/trivy-repo/test/deploy-stonking-fork/rpm/public.key
Key imported successfully
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                           1/1 
  Installing       : trivy-0.71.0-1.aarch64                                                                                                                    1/1 
  Verifying        : trivy-0.71.0-1.aarch64                                                                                                                    1/1 

Installed:
  trivy-0.71.0-1.aarch64                                                                                                                                           

Complete!
Version: 0.71.0

```

