### PR TITLE
ci!: publish deb packages only to the generic distribution

### DIFF
--- a/.github/workflows/deploy-packages.yml
+++ b/.github/workflows/deploy-packages.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get -y update
-          sudo apt-get -y install rpm reprepro createrepo-c distro-info
+          sudo apt-get -y install rpm reprepro createrepo-c
 
       - name: Download release assets
         env:

--- a/ci/deploy-deb.sh
+++ b/ci/deploy-deb.sh
@@ -2,27 +2,15 @@
 
 set -eu
 
-# "sid" and "experimental" are Debian pseudo-distributions, not stable releases.
-# They are included in `debian-distro-info --supported` output but have no reprepro
-# distributions entry and are not meaningful targets for a package repository.
-DEBIAN_RELEASES=$(debian-distro-info --supported | grep -vE "^(experimental|sid)$")
-UBUNTU_RELEASES=$(sort -u <(ubuntu-distro-info --supported-esm) <(ubuntu-distro-info --supported))
-
+# Trivy ships a single static binary, so the .deb is identical across every
+# Debian/Ubuntu release. We publish to a single codename-agnostic `generic`
+# distribution, which is the value used in the install docs.
 cd deb
 
-for release in generic ${DEBIAN_RELEASES[@]} ${UBUNTU_RELEASES[@]}; do
-  echo "Removing deb package of $release"
-  reprepro -A i386 remove $release trivy
-  reprepro -A amd64 remove $release trivy
-  reprepro -A arm64 remove $release trivy
-done
-
-for release in generic ${DEBIAN_RELEASES[@]} ${UBUNTU_RELEASES[@]}; do
-  echo "Adding deb package to $release"
-  reprepro includedeb $release ../dist/*Linux-32bit.deb
-  reprepro includedeb $release ../dist/*Linux-64bit.deb
-  reprepro includedeb $release ../dist/*Linux-ARM64.deb
-done
+echo "Adding deb package to generic"
+reprepro includedeb generic ../dist/*Linux-32bit.deb
+reprepro includedeb generic ../dist/*Linux-64bit.deb
+reprepro includedeb generic ../dist/*Linux-ARM64.deb
 
 # git runs inside `deb/`, so "git add ." stages only `deb/` contents.
 git add .


### PR DESCRIPTION
## Description

Trivy is a single static binary, so the `.deb` is identical for every Debian/Ubuntu release. The deploy published that same package to one `reprepro` distribution per codename, driven by a dynamic `distro-info --supported` list — so every new Ubuntu/Debian codename broke the deploy with `Cannot find definition of distribution` until a matching `conf/distributions` entry was added by hand.

The install docs have used the codename-agnostic `generic` distribution since [aquasecurity/trivy#6606](https://github.com/aquasecurity/trivy/pull/6606), so per-codename distributions are already legacy. This publishes only to `generic` and drops the `distro-info` dependency.

The explicit `reprepro remove` is also gone: `includedeb` already replaces the previous version in the distribution (reprepro keeps a single version), so the extra step is redundant.

Existing per-codename distributions and their published `dists/` are left untouched, so users still pinned to a codename keep working (frozen at the last published version) instead of getting `apt update` errors.

## Tests

Deployed in a fork (starting from `generic` at `0.71.0`) and ran the workflow with a newer version, `v0.999.4`:

- Workflow run: https://github.com/DmitriyLewen/trivy-repo/actions/runs/26808283101
- Resulting commit: https://github.com/DmitriyLewen/trivy-repo/commit/933f41e84455387525ec5bdada11a0c1acb3096b

| distribution | before | after deploy |
| --- | --- | --- |
| `generic` | 0.71.0 | **0.999.4** (replaced) |
| `noble` (legacy) | 0.71.0 | 0.71.0 (frozen) |
| `bookworm` (legacy) | 0.71.0 | 0.71.0 (frozen) |

This confirms that dropping the explicit `reprepro remove` is safe: `includedeb` of the newer `0.999.4` replaced `0.71.0` in `generic` on its own — `reprepro` keeps a single version per distribution, so there are no duplicates and no leftover `0.999`-line entries. The old `0.71.0` stays in `deb/pool/` only because the frozen per-codename distributions still reference it, which is exactly why those users keep working. The deploy completed cleanly under `set -eu`.

Installed the package from `generic` on Ubuntu and Debian:

```console
$ docker run --rm ubuntu:24.04 bash -c '
  apt-get update && apt-get install -y wget gnupg
  wget -qO - https://raw.githubusercontent.com/DmitriyLewen/trivy-repo/test/deploy-generic-only-fork/deb/public.key | gpg --dearmor | tee /usr/share/keyrings/trivy.gpg > /dev/null
  echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://raw.githubusercontent.com/DmitriyLewen/trivy-repo/test/deploy-generic-only-fork/deb generic main" | tee /etc/apt/sources.list.d/trivy.list
  apt-get update && apt-get install -y trivy && trivy --version'
...
The following NEW packages will be installed:
  trivy
0 upgraded, 1 newly installed, 0 to remove and 7 not upgraded.
Need to get 47.7 MB of archives.
Version: 0.999.4
```

```console
$ docker run --rm debian:bookworm bash -c '
  apt-get update && apt-get install -y wget gnupg
  wget -qO - https://raw.githubusercontent.com/DmitriyLewen/trivy-repo/test/deploy-generic-only-fork/deb/public.key | gpg --dearmor | tee /usr/share/keyrings/trivy.gpg > /dev/null
  echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://raw.githubusercontent.com/DmitriyLewen/trivy-repo/test/deploy-generic-only-fork/deb generic main" | tee /etc/apt/sources.list.d/trivy.list
  apt-get update && apt-get install -y trivy && trivy --version'
...
The following NEW packages will be installed:
  trivy
0 upgraded, 1 newly installed, 0 to remove and 2 not upgraded.
Need to get 43.1 MB of archives.
Version: 0.999.4
```

## Related PRs

- #54

> [!WARNING]
> Merge right before v0.72.0 to avoid this change in patch releases.
